### PR TITLE
docs: fix the name of the default model in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ require('copilot').setup({
   copilot_node_command = 'node', -- Node.js version must be > 18.x
   workspace_folders = {},
   server_opts_overrides = {},
-  copilot_model = "",  -- Current LSP default is gpt-35-turbo, supports gpt-4o-copilot
+  copilot_model = "",  -- Current LSP default is copilot-codex, supports gpt-4o-copilot
   get_root_dir = function()
     vim.fs.dirname(vim.fs.find(".git", { path = ".", upward = true })[1])
   end,


### PR DESCRIPTION
I think that the name of the default model is "copilot-codex" (a model based on GPT-3.5).

With [mitm-proxy](https://mitmproxy.org/) running (`mitmweb --set listen_port=4141`), I exported this env variable:
`﻿export HTTPS_PROXY=http://localhost:4141`.

Then I open NeoVim and start to interact with GitHub Copilot.
In that way, I can intercept requests to GitHub servers.

<img width="566" alt="Screenshot 2025-03-19 at 14 08 22" src="https://github.com/user-attachments/assets/7b65c13c-07a4-4450-82bb-c95be15f5def" />
